### PR TITLE
struct, class, protocolの訳語を再考する

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Swiftの用語がかなりバラバラなので、統一のために訳語集を
 
 訳語 | 原語 | 捕捉
 ----|------|------------
-構造体 | structure |
-クラス | class |
+実値型 | structure |
+参照型 | class |
 列挙型 | enumeration |
-プロトコル | protocol |
+要求型 | protocol |
 総称 | generics | Javaで一般的な用語の「ジェネリクス」も併用してよい
 変異メソッド | mutating method |
 パターンズ | patterns | パターンマッチや変数の初期化に使われるパターンの仕様のこと。 cf. [Patterns](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Patterns.html)


### PR DESCRIPTION
struct, class, protocolをそれぞれ実値型・参照型・要求型にしてはどうかと考えました。

structとclassはC言語由来だと思いますが、これをそれぞれ値のセマンティクスをもつ型、参照のセマンティクスをもつ型と（再）解釈したのはおそらくC#あたりです。しかし、この再解釈によって単語と意味が離れてしまったと感じます。Swiftは新しい言語ですし、訳語には正しい意味を与えるべきではないかと考えました。

慣習のほうが大事という意見があるのは承知していますが、新しいプロジェクトにレガシーコードをコピペしたらコードレビューではじくべきでしょう。コードならば当たり前のことを、翻訳でやってもいいはずです。

参考スレ： https://twitter.com/dankogai/status/551991458597588992 (thanks to dankogai)
