### PR TITLE
s/プロトコル/要求型/

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Swiftの用語がかなりバラバラなので、統一のために訳語集を
 構造体 | structure |
 クラス | class |
 列挙型 | enumeration |
-プロトコル | protocol |
+要求型 | protocol |
 総称 | generics | Javaで一般的な用語の「ジェネリクス」も併用してよい
 変異メソッド | mutating method |
 パターンズ | patterns | パターンマッチや変数の初期化に使われるパターンの仕様のこと。 cf. [Patterns](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Patterns.html)


### PR DESCRIPTION
メソッドやプロパティなどのインターフェイスを要求するという意味で **protocol** を **要求型** はどうかという提案です。

副次的ですが、TCPやHTTPなどのプロトコルと区別できるというメリットもあります。

参考: https://github.com/gfx/swift-words/pull/2
