### PR TITLE
s/変異メソッド/破壊的メソッド/

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Swiftの用語がかなりバラバラなので、統一のために訳語集を
 列挙型 | enumeration |
 プロトコル | protocol |
 総称 | generics | Javaで一般的な用語の「ジェネリクス」も併用してよい
-変異メソッド | mutating method |
+破壊的メソッド | mutating method |
 パターンズ | patterns | パターンマッチや変数の初期化に使われるパターンの仕様のこと。 cf. [Patterns](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Patterns.html)
 格納プロパティ | stored property |
 算出プロパティ | computed property |


### PR DESCRIPTION
`mutating method` の訳語は「破壊的メソッド」が一般的かつ妥当ではないかと思いました。

cc: @yuseinishiyama
